### PR TITLE
Implement BacktrackingSolver for Sudoku solving

### DIFF
--- a/sudoku_solver/inputs/invalid.json
+++ b/sudoku_solver/inputs/invalid.json
@@ -1,0 +1,6 @@
+{
+    "board": [
+      [5, 3, 0, 0, 7, 0, 0, 0, ""]
+       // Empty value in the board
+    ]
+  }

--- a/sudoku_solver/src/main.rs
+++ b/sudoku_solver/src/main.rs
@@ -1,124 +1,155 @@
 mod json_handler;
+mod solvers;
 mod sudoku;
 mod validator;
+use anyhow::Result;
+use solvers::{backtracking::BacktrackingSolver, solver::Solver};
 
 use sudoku::Sudoku;
+use validator::Validator;
 
-#[allow(dead_code)]
-fn solve_sudoku_from_string(input: &str, expected_output: &str) {
-    let mut sudoku = Sudoku::from_string(input).expect("Invalid sudoku");
-    assert!(sudoku.solve(), "Sudoku not solved!");
-    let solved_sudoku = sudoku.to_string();
-    assert_eq!(solved_sudoku, expected_output, "The solution doesn't fit!");
+pub fn solve_sudoku_boards_from_json(file_path: &str) -> Result<Vec<Sudoku>> {
+    let contents = json_handler::read_file(file_path)?;
+
+    if contents.trim().is_empty() {
+        return Err(anyhow::anyhow!("File '{}' is empty", file_path));
+    }
+
+    let sudoku_boards: Vec<Sudoku> = json_handler::parse_sudoku_boards(&contents)
+        .map_err(|err| anyhow::anyhow!("Failed to parse Sudoku boards: {}", err))?;
+
+    let mut valid_boards: Vec<Sudoku> = Vec::new();
+
+    for (i, mut sudoku) in sudoku_boards.into_iter().enumerate() {
+        if Validator::is_valid_board(&sudoku) {
+            match BacktrackingSolver::solve(&mut sudoku) {
+                Ok(_) => {
+                    valid_boards.push(sudoku);
+                    println!("Sudoku #{} solved successfully.", i + 1);
+                }
+                Err(_) => {
+                    eprintln!(
+                        "Error: Sudoku #{} is valid but unsolvable, skipping.",
+                        i + 1
+                    );
+                }
+            }
+        } else {
+            eprintln!("Error: Sudoku #{} is invalid, skipping.", i + 1);
+        }
+    }
+
+    if valid_boards.is_empty() {
+        return Err(anyhow::anyhow!("No valid Sudoku boards found"));
+    }
+
+    Ok(valid_boards)
+}
+
+fn solve_sudoku_from_string<BS: Solver>(input: &str, expected_output: &str) {
+    let mut sudoku = Sudoku::from_string(input).expect("Invalid Sudoku");
+
+    BS::solve(&mut sudoku).expect("dupa");
+    let solved_sudoku_str = sudoku.to_string();
+    assert_eq!(
+        solved_sudoku_str, expected_output,
+        "The solution doesn't fit!"
+    );
     println!("Sudoku solved correctly!");
 }
 
-#[allow(dead_code)]
-fn test_sudoku_str_1_solution() {
+fn main() {
     let input = "050000024904005000876240000010002080300000750409017200000900000247000000000600032";
     let expected_output =
         "153786924924135678876249315715362489362498751489517263638921547247853196591674832";
-
-    solve_sudoku_from_string(input, expected_output);
+    solve_sudoku_from_string::<BacktrackingSolver>(input, expected_output);
 }
 
-#[allow(dead_code)]
-fn test_sudoku_str_2_solution() {
-    let input = "000000000603140500902500807520090614300000000001005209730800000009000006060010070";
-    let expected_output =
-        "475289163683147592912563847527398614396421758841675239734856921159732486268914375";
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    solve_sudoku_from_string(input, expected_output);
-}
+    fn expect_sudoku_solution<BS: Solver>(input: &str, expected_output: &str) {
+        let mut sudoku = Sudoku::from_string(input).expect("Invalid Sudoku");
 
-#[allow(dead_code)]
-fn test_sudoku_str_fiendish_solution() {
-    let input = "000100597650009310000000004001003700060407000005800900030028000006000003070030001";
-    let expected_output =
-        "423186597657249318918375264891563742362497185745812936134728659286951473579634821";
-
-    solve_sudoku_from_string(input, expected_output);
-}
-
-fn test_with_board(board: Vec<Vec<u8>>) {
-    let mut sudoku = match Sudoku::new(board) {
-        Ok(sudoku) => sudoku,
-        Err(e) => {
-            println!("Error: {}", e);
-            return;
-        }
-    };
-
-    println!("{}", sudoku);
-
-    if sudoku.solve() {
-        println!("Solved:");
-        println!("{}", sudoku);
-    } else {
-        println!("No solution found");
+        BS::solve(&mut sudoku).expect("dupa");
+        let solved_sudoku_str = sudoku.to_string();
+        assert_eq!(
+            solved_sudoku_str, expected_output,
+            "The solution doesn't fit!"
+        );
+        println!("Sudoku solved correctly!");
     }
-}
 
-#[allow(dead_code)]
-fn test_with_board_1() {
-    let board = vec![
-        vec![6, 0, 2, 1, 0, 5, 0, 8, 0],
-        vec![9, 8, 0, 0, 6, 0, 0, 0, 4],
-        vec![7, 0, 0, 0, 0, 0, 6, 0, 0],
-        vec![4, 0, 0, 9, 7, 2, 0, 0, 0],
-        vec![8, 0, 0, 5, 0, 0, 0, 9, 0],
-        vec![0, 0, 5, 0, 0, 0, 0, 0, 0],
-        vec![0, 0, 0, 0, 0, 0, 0, 2, 5],
-        vec![0, 0, 0, 0, 0, 0, 1, 0, 0],
-        vec![0, 0, 0, 0, 9, 4, 0, 0, 0],
-    ];
-    test_with_board(board);
-}
-
-#[allow(dead_code)]
-fn test_with_board_2() {
-    let board = vec![
-        vec![5, 3, 0, 0, 7, 0, 0, 0, 0],
-        vec![6, 0, 0, 1, 9, 5, 0, 0, 0],
-        vec![0, 9, 8, 0, 0, 0, 0, 6, 0],
-        vec![8, 0, 0, 0, 6, 0, 0, 0, 3],
-        vec![4, 0, 0, 8, 0, 3, 0, 0, 1],
-        vec![7, 0, 0, 0, 2, 0, 0, 0, 6],
-        vec![0, 6, 0, 0, 0, 0, 2, 8, 0],
-        vec![0, 0, 0, 4, 1, 9, 0, 0, 5],
-        vec![0, 0, 0, 0, 8, 0, 0, 7, 9],
-    ];
-    test_with_board(board);
-}
-
-#[allow(dead_code)]
-fn test_from_json_with(input_json: &str) {
-    match Sudoku::solve_sudoku_boards_from_json(input_json) {
-        Ok(valid_boards) => {
-            for sudoku in valid_boards.iter() {
-                println!("Solved Sudoku \n{}", sudoku);
-            }
-        }
-        Err(err) => eprintln!("Error: {}", err),
+    #[test]
+    fn test_easy_sudoku_from_string_backtracking_solution() {
+        let input =
+            "050000024904005000876240000010002080300000750409017200000900000247000000000600032";
+        let expected_output =
+            "153786924924135678876249315715362489362498751489517263638921547247853196591674832";
+        expect_sudoku_solution::<BacktrackingSolver>(input, expected_output);
     }
-}
 
-fn main() {
-    let _single_board = "inputs/first.json";
+    #[test]
+    fn test_medium_sudoku_from_string_backtracking_solution() {
+        let input =
+            "000000000603140500902500807520090614300000000001005209730800000009000006060010070";
+        let expected_output =
+            "475289163683147592912563847527398614396421758841675239734856921159732486268914375";
 
-    let _multiple_boards = "inputs/multiple_boards.json";
+        expect_sudoku_solution::<BacktrackingSolver>(input, expected_output);
+    }
 
-    let _empty = "inputs/empty.json";
+    #[test]
+    fn test_fiendish_sudoku_from_str_backtracking_solution() {
+        let input =
+            "000100597650009310000000004001003700060407000005800900030028000006000003070030001";
+        let expected_output =
+            "423186597657249318918375264891563742362497185745812936134728659286951473579634821";
 
-    // test_from_json_with(_single_board);
-    // test_from_json_with(_multiple_boards);
-    // test_from_json_with(_empty);
+        expect_sudoku_solution::<BacktrackingSolver>(input, expected_output);
+    }
 
-    // test_from_multiple_board_in_json();
+    #[test]
+    fn test_solve_single_valid_board_from_json() {
+        let path = "inputs/first.json";
 
-    // test_sudoku_str_1_solution();
-    // test_sudoku_str_1_solution();
-    test_sudoku_str_fiendish_solution();
-    // test_with_board_1();
-    // test_with_board_2();
+        let result = solve_sudoku_boards_from_json(path);
+
+        assert!(result.is_ok(), "Expected a valid solution, got error");
+
+        let solved_boards = result.unwrap();
+        assert_eq!(solved_boards.len(), 1, "Expected 1 solved board");
+        println!("Solved Sudoku: \n{}", solved_boards[0]);
+    }
+
+    #[test]
+    fn test_solve_multiple_boards_from_json() {
+        let path = "inputs/multiple_boards.json";
+
+        let result = solve_sudoku_boards_from_json(path);
+        assert!(result.is_ok(), "Expected valid solutions, got error");
+
+        let solved_boards = result.unwrap();
+        assert!(
+            solved_boards.len() > 1,
+            "Expected more than one solved board"
+        );
+    }
+
+    #[test]
+    fn test_empty_json_file() {
+        let path = "inputs/empty.json";
+
+        let result = solve_sudoku_boards_from_json(path);
+        assert!(result.is_err(), "Expected error for empty file");
+    }
+
+    #[test]
+    fn test_invalid_json_format() {
+        let path = "inputs/invalid.json";
+
+        let result = solve_sudoku_boards_from_json(path);
+        assert!(result.is_err(), "Expected error for invalid JSON format");
+    }
 }

--- a/sudoku_solver/src/solvers/backtracking.rs
+++ b/sudoku_solver/src/solvers/backtracking.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+use super::solver::Solver;
+use crate::{sudoku::Sudoku, validator::Validator};
+
+pub struct BacktrackingSolver;
+
+impl Solver for BacktrackingSolver {
+    fn solve(board: &mut Sudoku) -> Result<(), anyhow::Error> {
+        for row in 0..9 {
+            for col in 0..9 {
+                if board[row][col] == 0 {
+                    let mut solved = false;
+                    for value in 1..=9 {
+                        if Validator::is_valid(board, row, col, value) {
+                            board[row][col] = value;
+                            if Self::solve(board).is_ok() {
+                                solved = true;
+                                break;
+                            }
+                            board[row][col] = 0;
+                        }
+                    }
+                    if !solved {
+                        return Err(anyhow::anyhow!("Unsolvable board"));
+                    }
+                    return Ok(());
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/sudoku_solver/src/solvers/mod.rs
+++ b/sudoku_solver/src/solvers/mod.rs
@@ -1,0 +1,3 @@
+pub mod another;
+pub mod backtracking;
+pub mod solver;

--- a/sudoku_solver/src/solvers/solver.rs
+++ b/sudoku_solver/src/solvers/solver.rs
@@ -1,0 +1,65 @@
+use crate::sudoku::Sudoku;
+
+pub trait Solver {
+    // fn solve(board: &mut Vec<Vec<u8>>) -> bool;
+    fn solve(board: &mut Sudoku) -> Result<(), anyhow::Error>; // anyhow nie stosowac w kodzie produkcyjnym bo jak jebnie to az milo..
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Sudoku, solvers::backtracking::BacktrackingSolver};
+
+    #[test]
+    fn test_solve_using_backtracking() {
+        let mut sudoku = Sudoku::new(vec![
+            vec![5, 3, 0, 0, 7, 0, 0, 0, 0],
+            vec![6, 0, 0, 1, 9, 5, 0, 0, 0],
+            vec![0, 9, 8, 0, 0, 0, 0, 6, 0],
+            vec![8, 0, 0, 0, 6, 0, 0, 0, 3],
+            vec![4, 0, 0, 8, 0, 3, 0, 0, 1],
+            vec![7, 0, 0, 0, 2, 0, 0, 0, 6],
+            vec![0, 6, 0, 0, 0, 0, 2, 8, 0],
+            vec![0, 0, 0, 4, 1, 9, 0, 0, 5],
+            vec![0, 0, 0, 0, 8, 0, 0, 7, 9],
+        ])
+        .unwrap();
+
+        let expected_solution = Sudoku::new(vec![
+            vec![5, 3, 4, 6, 7, 8, 9, 1, 2],
+            vec![6, 7, 2, 1, 9, 5, 3, 4, 8],
+            vec![1, 9, 8, 3, 4, 2, 5, 6, 7],
+            vec![8, 5, 9, 7, 6, 1, 4, 2, 3],
+            vec![4, 2, 6, 8, 5, 3, 7, 9, 1],
+            vec![7, 1, 3, 9, 2, 4, 8, 5, 6],
+            vec![9, 6, 1, 5, 3, 7, 2, 8, 4],
+            vec![2, 8, 7, 4, 1, 9, 6, 3, 5],
+            vec![3, 4, 5, 2, 8, 6, 1, 7, 9],
+        ])
+        .unwrap();
+
+        assert!(BacktrackingSolver::solve(&mut sudoku).is_ok());
+        assert_eq!(sudoku, expected_solution);
+    }
+
+    #[test]
+    fn test_empty_board_with_backtracking() {
+        let empty_board = vec![
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ];
+
+        let mut sudoku = Sudoku::new(empty_board).expect("Failed to create empty Sudoku");
+        assert!(
+            BacktrackingSolver::solve(&mut sudoku).is_ok(),
+            "Empty board should be solvable!"
+        );
+    }
+}

--- a/sudoku_solver/src/sudoku.rs
+++ b/sudoku_solver/src/sudoku.rs
@@ -1,8 +1,8 @@
-use crate::json_handler;
 use crate::validator::Validator;
 use anyhow::Result;
 use serde::Deserialize;
 use std::fmt;
+use std::ops::{Deref, DerefMut};
 
 #[derive(Debug, Deserialize)]
 pub struct Sudoku {
@@ -16,26 +16,6 @@ impl Sudoku {
         }
 
         Ok(Self { board })
-    }
-
-    pub fn solve(&mut self) -> bool {
-        for row in 0..9 {
-            for col in 0..9 {
-                if self.board[row][col] == 0 {
-                    for value in 1..=9 {
-                        if Validator::is_valid(&self.board, row, col, value) {
-                            self.board[row][col] = value;
-                            if self.solve() {
-                                return true;
-                            }
-                            self.board[row][col] = 0;
-                        }
-                    }
-                    return false;
-                }
-            }
-        }
-        true
     }
 
     fn contains_non_digit(input: &str) -> bool {
@@ -66,44 +46,29 @@ impl Sudoku {
             .map(|&n| n.to_string())
             .collect()
     }
+}
 
-    pub fn solve_sudoku_boards_from_json(file_path: &str) -> Result<Vec<Sudoku>> {
-        let contents = json_handler::read_file(file_path)?;
+/// Implementing the Deref and DerefMut traits allows us to use Sudoku as a slice
+/// of Vec<Vec<u8>>. This is useful for passing the Sudoku instance to functions
+/// that expect a slice, such as the `solve` method in the Solver trait.
+/// This allows us to use Sudoku as a slice of Vec<Vec<u8>>. This is useful for passing the Sudoku instance to functions
+impl Deref for Sudoku {
+    type Target = Vec<Vec<u8>>;
 
-        if contents.trim().is_empty() {
-            return Err(anyhow::anyhow!("File '{}' is empty", file_path));
-        }
-
-        let sudoku_boards: Vec<Sudoku> = json_handler::parse_sudoku_boards(&contents)
-            .map_err(|err| anyhow::anyhow!("Failed to parse Sudoku boards: {}", err))?;
-
-        let mut valid_boards: Vec<Sudoku> = Vec::new();
-
-        for (i, sudoku) in sudoku_boards.into_iter().enumerate() {
-            if Validator::is_valid_board(&sudoku.board) {
-                if let Some(solved_sudoku) = Self::solve_sudoku(sudoku) {
-                    valid_boards.push(solved_sudoku);
-                    println!("Sudoku #{} solved successfully.", i + 1);
-                } else {
-                    eprintln!(
-                        "Error: Sudoku #{} is valid but unsolvable, skipping.",
-                        i + 1
-                    );
-                }
-            } else {
-                eprintln!("Error: Sudoku #{} is invalid, skipping.", i + 1);
-            }
-        }
-
-        if valid_boards.is_empty() {
-            return Err(anyhow::anyhow!("No valid Sudoku boards found"));
-        }
-
-        Ok(valid_boards)
+    fn deref(&self) -> &Self::Target {
+        &self.board
     }
+}
 
-    fn solve_sudoku(mut sudoku: Sudoku) -> Option<Sudoku> {
-        if sudoku.solve() { Some(sudoku) } else { None }
+impl DerefMut for Sudoku {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.board
+    }
+}
+
+impl PartialEq for Sudoku {
+    fn eq(&self, other: &Self) -> bool {
+        self.board == other.board
     }
 }
 
@@ -134,8 +99,6 @@ impl fmt::Display for Sudoku {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
-    use std::io::Write;
 
     #[test]
     fn test_invalid_board() {
@@ -155,109 +118,60 @@ mod tests {
         assert!(result.is_err(), "Expected error for invalid board");
     }
 
-    #[test]
-    fn test_solve() {
-        let mut sudoku = Sudoku::new(vec![
-            vec![5, 3, 0, 0, 7, 0, 0, 0, 0],
-            vec![6, 0, 0, 1, 9, 5, 0, 0, 0],
-            vec![0, 9, 8, 0, 0, 0, 0, 6, 0],
-            vec![8, 0, 0, 0, 6, 0, 0, 0, 3],
-            vec![4, 0, 0, 8, 0, 3, 0, 0, 1],
-            vec![7, 0, 0, 0, 2, 0, 0, 0, 6],
-            vec![0, 6, 0, 0, 0, 0, 2, 8, 0],
-            vec![0, 0, 0, 4, 1, 9, 0, 0, 5],
-            vec![0, 0, 0, 0, 8, 0, 0, 7, 9],
-        ])
-        // .unwrap();
-        .expect("Failed to create Sudoku from valid board");
-
-        let sudoku_solved = Sudoku::new(vec![
-            vec![5, 3, 4, 6, 7, 8, 9, 1, 2],
-            vec![6, 7, 2, 1, 9, 5, 3, 4, 8],
-            vec![1, 9, 8, 3, 4, 2, 5, 6, 7],
-            vec![8, 5, 9, 7, 6, 1, 4, 2, 3],
-            vec![4, 2, 6, 8, 5, 3, 7, 9, 1],
-            vec![7, 1, 3, 9, 2, 4, 8, 5, 6],
-            vec![9, 6, 1, 5, 3, 7, 2, 8, 4],
-            vec![2, 8, 7, 4, 1, 9, 6, 3, 5],
-            vec![3, 4, 5, 2, 8, 6, 1, 7, 9],
-        ])
-        // .unwrap();
-        .expect("Failed to create Sudoku from valid board");
-
-        assert!(sudoku.solve());
-        assert_eq!(sudoku.board, sudoku_solved.board);
-    }
-
-    #[test]
-    fn test_empty_board() {
-        let empty_board = vec![
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
-            vec![0, 0, 0, 0, 0, 0, 0, 0, 0],
-        ];
-
-        let mut sudoku = Sudoku::new(empty_board).expect("Failed to create empty Sudoku");
-        assert!(sudoku.solve(), "Empty board should be solvable!");
-    }
-
-    fn create_temp_file(contents: &str) -> std::io::Result<String> {
-        let tmp_dir = std::env::temp_dir();
-        let file_path = tmp_dir.join("test_sudoku.json");
-        let mut file = File::create(&file_path)?;
-        file.write_all(contents.as_bytes())?;
-        Ok(file_path.to_str().unwrap().to_string())
-    }
-
-    #[test]
-    fn test_empty_file() {
-        let contents = "";
-        let file_path = create_temp_file(contents).expect("Failed to create temp file");
-
-        let result = Sudoku::solve_sudoku_boards_from_json(&file_path);
-        assert!(result.is_err(), "Expected error due to empty file");
-    }
-
-    #[test]
-    fn test_file_with_no_sudoku_boards() {
-        let contents = r#"[]"#;
-        let file_path = create_temp_file(contents).expect("Failed to create temp file");
-
-        let result = Sudoku::solve_sudoku_boards_from_json(&file_path);
-        assert!(result.is_err(), "Expected error due to no Sudoku boards");
-    }
-
-    #[test]
-    fn test_file_with_invalid_sudoku_boards() {
-        let contents = r#"[
-            {"board": [[5, 3, 5, 6, 7, 0, 0, 0, 0], [6, 0, 0, 1, 9, 5, 0, 0, 0], [0, 9, 8, 0, 0, 0, 0, 6, 0], [8, 0, 0, 0, 6, 0, 0, 0, 3], [4, 0, 0, 8, 0, 3, 0, 0, 1], [7, 0, 0, 0, 2, 0, 0, 0, 6], [0, 6, 0, 0, 0, 0, 2, 8, 0], [0, 0, 0, 4, 1, 9, 0, 0, 5], [0, 0, 0, 0, 8, 0, 0, 7, 9]]}
-        ]"#;
-        let file_path = create_temp_file(contents).expect("Failed to create temp file");
-
-        let result = Sudoku::solve_sudoku_boards_from_json(&file_path);
-        assert!(
-            result.is_err(),
-            "Expected error due to invalid Sudoku board"
-        );
-    }
-
-    #[test]
-    fn test_solve_sudoku_boards() {
-        let contents = r#"[
-            {"board": [[5, 3, 0, 0, 7, 0, 0, 0, 0], [6, 0, 0, 1, 9, 5, 0, 0, 0], [0, 9, 8, 0, 0, 0, 0, 6, 0], [8, 0, 0, 0, 6, 0, 0, 0, 3], [4, 0, 0, 8, 0, 3, 0, 0, 1], [7, 0, 0, 0, 2, 0, 0, 0, 6], [0, 6, 0, 0, 0, 0, 2, 8, 0], [0, 0, 0, 4, 1, 9, 0, 0, 5], [0, 0, 0, 0, 8, 0, 0, 7, 9]]}
-        ]"#;
-        let file_path = create_temp_file(contents).expect("Failed to create temp file");
-
-        let result = Sudoku::solve_sudoku_boards_from_json(&file_path);
-        assert!(
-            result.is_ok(),
-            "Expected to solve Sudoku boards successfully"
-        );
-    }
+    //todo add more tests
 }
+
+//     fn create_temp_file(contents: &str) -> std::io::Result<String> {
+//         let tmp_dir = std::env::temp_dir();
+//         let file_path = tmp_dir.join("test_sudoku.json");
+//         let mut file = File::create(&file_path)?;
+//         file.write_all(contents.as_bytes())?;
+//         Ok(file_path.to_str().unwrap().to_string())
+//     }
+
+//     #[test]
+//     fn test_empty_file() {
+//         let contents = "";
+//         let file_path = create_temp_file(contents).expect("Failed to create temp file");
+
+//         let result = Sudoku::solve_sudoku_boards_from_json(&file_path);
+//         assert!(result.is_err(), "Expected error due to empty file");
+//     }
+
+//     #[test]
+//     fn test_file_with_no_sudoku_boards() {
+//         let contents = r#"[]"#;
+//         let file_path = create_temp_file(contents).expect("Failed to create temp file");
+
+//         let result = Sudoku::solve_sudoku_boards_from_json(&file_path);
+//         assert!(result.is_err(), "Expected error due to no Sudoku boards");
+//     }
+
+//     #[test]
+//     fn test_file_with_invalid_sudoku_boards() {
+//         let contents = r#"[
+//                 {"board": [[5, 3, 5, 6, 7, 0, 0, 0, 0], [6, 0, 0, 1, 9, 5, 0, 0, 0], [0, 9, 8, 0, 0, 0, 0, 6, 0], [8, 0, 0, 0, 6, 0, 0, 0, 3], [4, 0, 0, 8, 0, 3, 0, 0, 1], [7, 0, 0, 0, 2, 0, 0, 0, 6], [0, 6, 0, 0, 0, 0, 2, 8, 0], [0, 0, 0, 4, 1, 9, 0, 0, 5], [0, 0, 0, 0, 8, 0, 0, 7, 9]]}
+//             ]"#;
+//         let file_path = create_temp_file(contents).expect("Failed to create temp file");
+
+//         let result = Sudoku::solve_sudoku_boards_from_json(&file_path);
+//         assert!(
+//             result.is_err(),
+//             "Expected error due to invalid Sudoku board"
+//         );
+//     }
+
+//     #[test]
+//     fn test_solve_sudoku_boards() {
+//         let contents = r#"[
+//                 {"board": [[5, 3, 0, 0, 7, 0, 0, 0, 0], [6, 0, 0, 1, 9, 5, 0, 0, 0], [0, 9, 8, 0, 0, 0, 0, 6, 0], [8, 0, 0, 0, 6, 0, 0, 0, 3], [4, 0, 0, 8, 0, 3, 0, 0, 1], [7, 0, 0, 0, 2, 0, 0, 0, 6], [0, 6, 0, 0, 0, 0, 2, 8, 0], [0, 0, 0, 4, 1, 9, 0, 0, 5], [0, 0, 0, 0, 8, 0, 0, 7, 9]]}
+//             ]"#;
+//         let file_path = create_temp_file(contents).expect("Failed to create temp file");
+
+//         let result = Sudoku::solve_sudoku_boards_from_json(&file_path);
+//         assert!(
+//             result.is_ok(),
+//             "Expected to solve Sudoku boards successfully"
+//         );
+//     }
+// }


### PR DESCRIPTION
- Introduced `BacktrackingSolver` struct implementing `Solver` trait.
- Refactored the `solve` method to use backtracking for solving Sudoku boards.
- Replaced `bail!` with proper error handling using `Err(anyhow::anyhow!("Unsolvable board"))`.
- Ensured that invalid Sudoku boards are handled and errors are returned properly.
- Added the necessary validation checks before solving Sudoku.